### PR TITLE
Add title ID to start of packets

### DIFF
--- a/HokakuCTR.plgInfo
+++ b/HokakuCTR.plgInfo
@@ -3,7 +3,7 @@ Author: PretendoNetwork
 Version: # Plugin version
     Major: 1
     Minor: 0
-    Revision: 0
+    Revision: 2
 
 Targets: # Low TitleId of games which are compatibles with this plugin (empty for all)
 

--- a/Includes/RMCLogger.hpp
+++ b/Includes/RMCLogger.hpp
@@ -29,8 +29,9 @@ namespace CTRPluginFramework {
             u32 savedBytes;
             u32 packetBytes;
         };
-        struct PacketMetadata
+        struct PACKED PacketMetadata
         {
+			u64 titleID;
             struct {
                 u8 isRecievedPacked : 1;
                 u8 userPacketNote : 1;

--- a/Includes/RMCLogger.hpp
+++ b/Includes/RMCLogger.hpp
@@ -32,10 +32,7 @@ namespace CTRPluginFramework {
         struct PACKED PacketMetadata
         {
             u64 titleID;
-            struct {
-                u8 isRecievedPacked : 1;
-                u8 userPacketNote : 1;
-            } flags;
+            bool isRecievedPacket;
         };
         u64 titleID;
         File* pcapFile;

--- a/Includes/RMCLogger.hpp
+++ b/Includes/RMCLogger.hpp
@@ -31,7 +31,7 @@ namespace CTRPluginFramework {
         };
         struct PACKED PacketMetadata
         {
-			u64 titleID;
+            u64 titleID;
             struct {
                 u8 isRecievedPacked : 1;
                 u8 userPacketNote : 1;

--- a/Includes/RMCLogger.hpp
+++ b/Includes/RMCLogger.hpp
@@ -36,7 +36,7 @@ namespace CTRPluginFramework {
                 u8 userPacketNote : 1;
             } flags;
         };
-        
+        u64 titleID;
         File* pcapFile;
         Clock currentElapsed;
         time_t startTime;

--- a/Includes/RMCLogger.hpp
+++ b/Includes/RMCLogger.hpp
@@ -31,6 +31,7 @@ namespace CTRPluginFramework {
         };
         struct PACKED PacketMetadata
         {
+            u8 revision = 1;
             u64 titleID{};
             struct {
                 u8 isRecievedPacket : 1;

--- a/Includes/RMCLogger.hpp
+++ b/Includes/RMCLogger.hpp
@@ -31,8 +31,12 @@ namespace CTRPluginFramework {
         };
         struct PACKED PacketMetadata
         {
-            u64 titleID;
-            bool isRecievedPacket;
+            u64 titleID{};
+            struct {
+                u8 isRecievedPacket : 1;
+                u8 userPacketNote : 1;
+                u8 unused : 6;
+            } flags{};
         };
         u64 titleID;
         File* pcapFile;

--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -12,7 +12,7 @@ namespace CTRPluginFramework {
         std::string procName;
         Process::GetName(procName);
 
-		titleID = Process::GetTitleID();
+        titleID = Process::GetTitleID();
 
         finalFolder += "/" + procName + " - (" + tid + ")";
         if (!Directory::IsExists(finalFolder))

--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -29,7 +29,7 @@ namespace CTRPluginFramework {
         PcapHeader hdr;
         pcapFile->Write(&hdr, sizeof(PcapHeader));
 
-        writeBuffer = (u8*)operator new(maxPacketSize + sizeof(PcapPacketHeader) + sizeof(titleID));
+        writeBuffer = (u8*)operator new(maxPacketSize + sizeof(PcapPacketHeader));
     }
 
     void RMCLogger::Terminate() {

--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -59,7 +59,7 @@ namespace CTRPluginFramework {
 
         PacketMetadata metadata;
         metadata.titleID = titleID;
-        metadata.isRecievedPacket = isRecieved;
+        metadata.flags.isRecievedPacket = isRecieved;
         memcpy(writeBuffer + sizeof(PcapPacketHeader), &metadata, sizeof(PacketMetadata));
         
         memcpy(writeBuffer + sizeof(PcapPacketHeader) + sizeof(PacketMetadata), data, packetSize);

--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -29,7 +29,7 @@ namespace CTRPluginFramework {
         PcapHeader hdr;
         pcapFile->Write(&hdr, sizeof(PcapHeader));
 
-        writeBuffer = (u8*)operator new(maxPacketSize + sizeof(PcapPacketHeader));
+        writeBuffer = (u8*)operator new(maxPacketSize + sizeof(PcapPacketHeader) + sizeof(titleID));
     }
 
     void RMCLogger::Terminate() {

--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -59,7 +59,7 @@ namespace CTRPluginFramework {
 
         PacketMetadata metadata;
         metadata.titleID = titleID;
-        metadata.flags.isRecievedPacked = isRecieved;
+        metadata.isRecievedPacket = isRecieved;
         memcpy(writeBuffer + sizeof(PcapPacketHeader), &metadata, sizeof(PacketMetadata));
         
         memcpy(writeBuffer + sizeof(PcapPacketHeader) + sizeof(PacketMetadata), data, packetSize);

--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -12,7 +12,7 @@ namespace CTRPluginFramework {
         std::string procName;
         Process::GetName(procName);
 
-        titleID = Process::GetTitleID();
+		titleID = Process::GetTitleID();
 
         finalFolder += "/" + procName + " - (" + tid + ")";
         if (!Directory::IsExists(finalFolder))
@@ -44,11 +44,11 @@ namespace CTRPluginFramework {
     void RMCLogger::LogRMCPacket(const u8* data, u32 packetSize, bool isRecieved) {
         if (packetSize < 4 || ((u32*)data)[0] != packetSize - 4)
             return;
-        if (packetSize > maxPacketSize - sizeof(PacketMetadata) - sizeof(titleID)) {
+        if (packetSize > maxPacketSize - sizeof(PacketMetadata)) {
             OSD::Notify(Utils::Format("Packet too big! 0x%08X, 0x%08X", (u32)data, packetSize));
         }
         PcapPacketHeader* pHdr = reinterpret_cast<PcapPacketHeader*>(writeBuffer);
-        pHdr->savedBytes = pHdr->packetBytes = packetSize + sizeof(PacketMetadata) + sizeof(titleID);
+        pHdr->savedBytes = pHdr->packetBytes = packetSize + sizeof(PacketMetadata);
 
         s64 elapsedMsecTot = currentElapsed.GetElapsedTime().AsMicroseconds();
         u32 elapsedSec = elapsedMsecTot / 1000000;
@@ -58,12 +58,11 @@ namespace CTRPluginFramework {
         pHdr->microsecondoffset = elapsedMsec;
 
         PacketMetadata metadata;
+        metadata.titleID = titleID;
         metadata.flags.isRecievedPacked = isRecieved;
-
-        memcpy(writeBuffer + sizeof(PcapPacketHeader), &titleID, sizeof(titleID));
-        memcpy(writeBuffer + sizeof(PcapPacketHeader) + sizeof(titleID), &metadata, sizeof(PacketMetadata));
-        memcpy(writeBuffer + sizeof(PcapPacketHeader) + sizeof(titleID) + sizeof(PacketMetadata), data, packetSize);
-
-        pcapFile->Write(writeBuffer, sizeof(PcapPacketHeader) + sizeof(titleID) + sizeof(PacketMetadata) + packetSize);
+        memcpy(writeBuffer + sizeof(PcapPacketHeader), &metadata, sizeof(PacketMetadata));
+        
+        memcpy(writeBuffer + sizeof(PcapPacketHeader) + sizeof(PacketMetadata), data, packetSize);
+        pcapFile->Write(writeBuffer, sizeof(PcapPacketHeader) + sizeof(PacketMetadata) + packetSize);
     }
 }

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -161,7 +161,7 @@ namespace CTRPluginFramework
     // This function is called after the game starts executing and CTRPF is ready.
     int     main(void)
     {
-        OSD::Notify("HokakuCTR v1.0.1");
+        OSD::Notify("HokakuCTR v1.0.2");
 
         if (sendFuncAddr) {
             OSD::Notify(Utils::Format("Send RMC Addr: 0x%08X", sendFuncAddr));


### PR DESCRIPTION
Adds the games title ID to the beginning of all packets, to identify where they came from. This is useful for tools like [NEX Viewer](https://github.com/PretendoNetwork/nex-viewer), since to decode the RMC payload we need to know beforehand what NEX version is being used. Since the game is now known based on the title ID, the NEX version can also be easily looked up