### PR TITLE
Add mapping of process names to game names for more readable capture folders

### DIFF
--- a/Sources/RMCLogger.cpp
+++ b/Sources/RMCLogger.cpp
@@ -3,6 +3,19 @@
 
 namespace CTRPluginFramework {
     void RMCLogger::Initialize() {
+                std::map<std::string, std::string> gameNames = {
+            {"CENTER", "badge-arcade"},
+            {"ctrapp", "super-smash-bros3ds"},
+            {"kujira-1", "PokemonX"},
+            {"MarioKar", "mario-kart7"},
+            {"TAKUMI", "animal-crossing-happyHD"},
+            {"Kirby3DS", "Team-kirby-clash-deluxe"},
+            {"GARDEN", "animal-crossing-new-leaf"},
+            {"momiji", "pokemon-ultra-soleil"},
+            {"Rabbids", "rabbids-rumble"},
+            {"uniform", "mario-superstars"}
+        };
+
         std::string finalFolder = "/HokakuCTR";
         if (!Directory::IsExists(finalFolder))
             Directory::Create(finalFolder);
@@ -14,9 +27,18 @@ namespace CTRPluginFramework {
 
         titleID = Process::GetTitleID();
 
+        // Rechercher si le nom de processus commence par l'un des termes de la liste
+        for (const auto& gameName : gameNames) {
+            if (procName.find(gameName.first) == 0) {
+                procName.replace(0, gameName.first.length(), gameName.second);
+                break;
+            }
+        }
+
         finalFolder += "/" + procName + " - (" + tid + ")";
         if (!Directory::IsExists(finalFolder))
             Directory::Create(finalFolder);
+
         
         startTime = time(NULL);
         currentElapsed.Restart();


### PR DESCRIPTION
When a capture folder is created by the plugin, it can be difficult to understand the different game names based on the process name alone. This pull request adds a mapping of process names to more readable game names, so that the capture folders have more understandable names.

The mapping is stored in a std::map object called gameNames, which contains key-value pairs where the key is the process name and the value is the corresponding game name. The code then checks if the process name starts with any of the keys in the gameNames map, and if so, replaces the key with the corresponding value.

For example, if the process name is "ctrapp", the code will replace it with "super-smash-bros3ds". If the process name is "kujira-1", the code will replace it with "Pokemon X". If no match is found, the original process name is used.

If other process names and their corresponding sets are known, they should also be added.